### PR TITLE
Enable batch-install.sh to install on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci-test-ubuntu.yml
+++ b/.github/workflows/ci-test-ubuntu.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         # os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     steps:

--- a/batch-install.sh
+++ b/batch-install.sh
@@ -29,7 +29,7 @@ THIS_SCRIPT_DIR_ABSOLUTE=`readlink -f "${THIS_SCRIPT_DIR_MAYBE_RELATIVE}"`
 linux_version_warning() {
     1>&2 echo "Found ID ${ID} and VERSION_ID ${VERSION_ID} in /etc/os-release"
     1>&2 echo "This script only supports these:"
-    1>&2 echo "    ID ubuntu, VERSION_ID in 20.04"
+    1>&2 echo "    ID ubuntu, VERSION_ID in 20.04 22.04"
     1>&2 echo ""
     1>&2 echo "Proceed installing manually at your own risk of"
     1>&2 echo "significant time spent figuring out how to make it all"
@@ -54,6 +54,9 @@ if [ "${ID}" = "ubuntu" ]
 then
     case "${VERSION_ID}" in
 	20.04)
+	    supported_distribution=1
+	    ;;
+	22.04)
 	    supported_distribution=1
 	    ;;
     esac


### PR DESCRIPTION
I have run this batch-install.sh on a freshly installed Ubuntu 22.04 x86_64 system with these changes, and it builds and passes the basic test we have in CI right now (although it seems to take significantly longer to run the test, for reasons I have not tried to determine).