### PR TITLE
Add setup-open-p4studio.bash Configuration for install.sh Users

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,3 +21,15 @@ set -x
 readonly MY_PATH=$(realpath "$0")
 readonly MY_DIR=$(dirname "$MY_PATH")
 "$MY_DIR/p4studio/p4studio" interactive
+
+cd "${HOME}"
+cp /dev/null setup-open-p4studio.bash
+echo "export SDE=\"${THIS_SCRIPT_DIR_ABSOLUTE}\"" >> setup-open-p4studio.bash
+echo "export SDE_INSTALL=\"\${SDE}/install\"" >> setup-open-p4studio.bash
+echo "export LD_LIBRARY_PATH=\"\${SDE_INSTALL}/lib\"" >> setup-open-p4studio.bash
+echo "export PATH=\"\${SDE_INSTALL}/bin:\${PATH}\"" >> setup-open-p4studio.bash
+
+echo "If you use a Bash-like command shell, you may wish to add a line like"
+echo "the following to your .bashrc or other shell rc file:"
+echo ""
+echo "    source \$HOME/setup-open-p4studio.bash"

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,12 @@ readonly MY_PATH=$(realpath "$0")
 readonly MY_DIR=$(dirname "$MY_PATH")
 "$MY_DIR/p4studio/p4studio" interactive
 
+INSTALL_DIR="${PWD}"
+
+THIS_SCRIPT_FILE_MAYBE_RELATIVE="$0"
+THIS_SCRIPT_DIR_MAYBE_RELATIVE="${THIS_SCRIPT_FILE_MAYBE_RELATIVE%/*}"
+THIS_SCRIPT_DIR_ABSOLUTE=`readlink -f "${THIS_SCRIPT_DIR_MAYBE_RELATIVE}"`
+
 cd "${HOME}"
 cp /dev/null setup-open-p4studio.bash
 echo "export SDE=\"${THIS_SCRIPT_DIR_ABSOLUTE}\"" >> setup-open-p4studio.bash


### PR DESCRIPTION
This PR introduces the creation of a setup-open-p4studio.bash script specifically for users who utilize the install.sh script. The purpose of this script is to set up the necessary environment variables to ensure seamless operation of Open P4 Studio.