### PR TITLE
hw/rdc_setup.sh: fix typos, add missing files

### DIFF
--- a/hw/rdc_setup.sh
+++ b/hw/rdc_setup.sh
@@ -32,19 +32,25 @@ rdc_setup(){
     cp $RDC_BFD/$SUBDIR/CMakeLists.txt $OS_BFD/$SUBDIR/CMakeLists.txt
 
     SUBDIR="src"
-    DIRS=("alphawave" "credo" "firmware" "microp")
+    DIRS=("alphawave" "credo" "avago" "microp")
     replace "$SUBDIR" 1 "${DIRS[@]}" 
     cp $RDC_BFD/$SUBDIR/CMakeLists.txt $OS_BFD/$SUBDIR/CMakeLists.txt
 
+    cp $RDC_BFD/libavago* $OS_BFD
+
+    SUBDIR="include/avago"
+    FILES=("aapl.h" "avago_aapl.h" "avago_dox.h")
+    replace "$SUBDIR" 0 "${FILES[@]}"
+
     SUBDIR="src/port_mgr"
     # If port_mgr_dev.c or port_mgr_physical_dev.c are modified by the open source community, those changes must be merged manually by the user
-    FILES=("CMakeLists.txt" "bf_ll_umac3_if.c" "bf_ll_umac_4_if.c" "port_mgr_dev.c" "post_mgr_physical_dev.c" "port_mgr_umac_access.c" "t3-csr/tf3-csr-gen.py")
-    DIRS=("csr" "crdo" "aw-gen")
+    FILES=("CMakeLists.txt" "bf_ll_umac3_if.c" "bf_ll_umac4_if.c" "port_mgr_dev.c" "port_mgr_physical_dev.h" "port_mgr_umac_access.c")
+    DIRS=("csr" "crdo" "aw-gen" "t3-csr")
     replace "$SUBDIR" 1 "${DIRS[@]}"
     replace "$SUBDIR" 0 "${FILES[@]}"
 
     SUBDIR="src/port_mgr/port_mgr_tof1"
-    FILES=("bf_serdes_if.c" "comira_reg_access_autogen.c" "comira_reg_access_autogen.h" "comira_reg_def_autogen.h" "comira_reg_strs.h" "port_mgr_av_sd.c" "port_mgr_av_sd_an.c" "port_mgr_mac.c" "port_mgr_port_diag.c" "port_mgr_serdes.c" "port_mgr_serdes_diag.c" "port_mgr_serdes_sbus_map.c" "port_mgr_ucli.c")
+    FILES=("bf_serdes_if.c" "comira_reg_access_autogen.c" "comira_reg_access_autogen.h" "comira_reg_def_autogen.h" "comira_reg_strs.h" "port_mgr_av_sd.c" "port_mgr_av_sd.h" "port_mgr_av_sd_an.c" "port_mgr_av_sd_an.h" "port_mgr_mac.c" "port_mgr_port_diag.c" "port_mgr_serdes.c" "port_mgr_serdes_diag.c" "port_mgr_serdes_sbus_map.c" "port_mgr_ucli.c" "bf_fsm_hdlrs.c" )
     replace "$SUBDIR" 0 "${FILES[@]}"
 
     SUBDIR="src/port_mgr/port_mgr_tof2"
@@ -54,7 +60,7 @@ rdc_setup(){
     SUBDIR="src/port_mgr/port_mgr_tof3"
     # If aw_if.h, aw_mss.h, or bf_tof3_serdes_utils.h are modified by the open source community, those changes must be merged manually by the user
     FILES=("aw_driver_sim.c" "aw_driver_sim.h" "aw_if.h" "aw_io.c" "aw_io.h" "aw_mss.h" "aw_reg_dbg.c" "aw_reg_dbg.h" "aw_types.h" "aw_vector_types.h" "bf_aw_pmd.c" "bf_aw_vfld_pmd.c" "bf_ll_tof3_eth400g_app_rspec_if.c" "bf_ll_tof3_eth400g_app_rspec_if.h" "bf_ll_tof3_eth400g_mac_rspec_if.c" "bf_ll_tof3_eth400g_mac_rspec_if.h" "bf_ll_tof3_eth400g_sys_rspec_if.c" "bf_ll_tof3_eth400g_sys_rspec_if.h" "bf_tof3_serdes_if.c" "bf_tof3_serdes_utils.c" "bf_tof3_serdes_utils.h" "port_mgr_tof3.c" "port_mgr_tof3_dev.c" "port_mgr_tof3_map.c" "port_mgr_tof3_microp.c" "port_mgr_tof3_port.c" "port_mgr_tof3_serdes.c" "port_mgr_tof3_serdes_map.c" "port_mgr_tof3_tmac.c" "svdpi.c" "svdpi.h" "tmac_access.c" "tmac_access.h" "tof3-autogen-required-headers.h" "tof3_eth400g_app_rspec_access.c" "tof3_eth400g_app_rspec_access.h" "tof3_eth400g_mac_rspec_access.c" "tof3_eth400g_mac_rspec_access.h" "tof3_eth400g_sys_rspec_access.c" "tof3_eth400g_sys_rspec_access.h" "vfld_vec_name.h" "vfld_vec_type.h")
-    DIRS=("aw-reg-gen" "aw_16ln")
+    DIRS=("aw-reg-gen" "aw_16ln" "aw_4ln")
     replace "$SUBDIR" 1 "${DIRS[@]}"
     replace "$SUBDIR" 0 "${FILES[@]}"
 }


### PR DESCRIPTION
This PR contains the changes that I found necessary for building the project for the Tofino reference platforms.

Apart from some obvious typos and missing directories for source and header files, it appears to me that the `libavago` pre-built binaries need to be copied as well.
