### PR TITLE
Fix optional match key mask using XOR instead of shift

### DIFF
--- a/pkgsrc/bf-drivers/src/bf_rt/bf_rt_p4/bf_rt_p4_table_key_impl.cpp
+++ b/pkgsrc/bf-drivers/src/bf_rt/bf_rt_p4/bf_rt_p4_table_key_impl.cpp
@@ -368,7 +368,7 @@ bf_status_t BfRtMatchActionKey::setValueOptional(const bf_rt_id_t &field_id,
   auto size_bytes = (field_size + 7) / 8;
   uint64_t mask = 0;
   if (is_valid) {
-    mask = (2 ^ field_size) - 1;
+    mask = (field_size < 64) ? ((1ULL << field_size) - 1) : UINT64_MAX;
   }
 
   // endianness conversion


### PR DESCRIPTION
`BfRtMatchActionKey::setValueOptional` builds the mask for a valid optional key as `(2 ^ field_size) - 1`, treating `^` as exponentiation. In C++ this is bitwise XOR, so the mask is wrong for essentially every field size — e.g. an 8-bit field gets `(2 XOR 8) - 1 = 9` (`0b00001001`) instead of `0xFF`, and a 2-bit field underflows to an all-ones mask. As a result, optional match keys set through BF-RT match against incorrect bits instead of performing an exact match on the full field.

This computes the mask as `(1ULL << field_size) - 1`, falling back to `UINT64_MAX` for 64-bit fields since shifting by the full type width is undefined behavior.