### PR TITLE
fix: Use legacy version of libcrafter

### DIFF
--- a/p4studio/dependencies/dependencies.yaml
+++ b/p4studio/dependencies/dependencies.yaml
@@ -351,7 +351,7 @@ packages:
         dependencies: [boost]
         type: source
     libcrafter:
-        attributes: {url: 'https://github.com/pellegre/libcrafter.git', version: master}
+        attributes: {url: 'https://github.com/pellegre/libcrafter.git', version: eb3a120b6650a4cada9e00055c56ec35f3360e13}
         tags: [default, source]
         dependencies: [libcli]
         type: source


### PR DESCRIPTION
## Changes

- Fix: Change the "libcrafter" version to https://github.com/pellegre/libcrafter/tree/eb3a120b6650a4cada9e00055c56ec35f3360e13

- The ./autogen.sh called by install_libcrafter.py is supposed to be the legacy version. 
However, the current master branch has been refactor in Rust, so the way it needs to be built and executed has changed.

- The issue on Linux KVM Ubuntu 20.04.06


## Related Issues

- https://github.com/p4lang/open-p4studio/issues/134

## Self-Check

- [X] Tests have been run
- [X] No unnecessary debug code
- [ ] Necessary annotations have been added
- [X] Existing functionality is not affected